### PR TITLE
Update Node.js to 24 LTS

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary

Update Node.js to 24.x (Active LTS - Krypton).

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)